### PR TITLE
Inject SmartyFactory instead of Smarty

### DIFF
--- a/src/SmartyConsoleServiceProvider.php
+++ b/src/SmartyConsoleServiceProvider.php
@@ -78,7 +78,7 @@ class SmartyConsoleServiceProvider extends ServiceProvider
 
         // clear compiled
         $this->app->singleton('command.ytake.laravel-smarty.clear.compiled', function ($app) {
-            return new Console\ClearCompiledCommand($app['smarty.view']->getSmarty());
+            return new Console\ClearCompiledCommand($app['smarty.view']);
         });
 
         // clear compiled


### PR DESCRIPTION
Just figured that I did not update the service provider. Though tests work, the service container injects the wrong object.