### PR TITLE
Cleaner ytake:smarty-optimize command output

### DIFF
--- a/src/Console/OptimizeCommand.php
+++ b/src/Console/OptimizeCommand.php
@@ -77,8 +77,8 @@ class OptimizeCommand extends Command
         );
         $contents = ob_get_contents();
         ob_get_clean();
-        $this->info("{$compileFiles} template files recompiled.");
-        $this->comment(str_replace("<br>", "\n", trim($contents)));
+        $this->comment(str_replace("<br>", "", trim($contents)));
+        $this->info("{$compileFiles} template files recompiled");
         return;
     }
 


### PR DESCRIPTION
Output the number of recompiled files last so you don't have to scroll up. Also, replace <br> with nothing to avoid unneeded new lines