### PR TITLE
More consistent view name output with view composers

### DIFF
--- a/src/Engines/SmartyTemplate.php
+++ b/src/Engines/SmartyTemplate.php
@@ -32,22 +32,120 @@ class SmartyTemplate extends \Smarty_Internal_Template
     /**
      * {@inheritdoc}
      */
-    public function _subTemplateRegister()
+    public function _subTemplateRender($template, $cache_id, $compile_id, $caching, $cache_lifetime, $data, $scope,
+                                       $forceTplCache, $uid = null, $content_func = null)
     {
-        foreach ($this->compiled->includes as $name => $count) {
-            if (isset($this->smarty->_cache['subTplInfo'][$name])) {
-                $this->smarty->_cache['subTplInfo'][$name] += $count;
+        $tpl = clone $this;
+        $tpl->parent = $this;
+        $smarty = &$this->smarty;
+        $_templateId = $smarty->_getTemplateId($template, $cache_id, $compile_id, $caching, $tpl);
+        // recursive call ?
+        if (isset($tpl->templateId) ? $tpl->templateId : $tpl->_getTemplateId() != $_templateId) {
+            // already in template cache?
+            if (isset($smarty->_cache[ 'tplObjects' ][ $_templateId ])) {
+                // copy data from cached object
+                $cachedTpl = &$smarty->_cache[ 'tplObjects' ][ $_templateId ];
+                $tpl->templateId = $cachedTpl->templateId;
+                $tpl->template_resource = $cachedTpl->template_resource;
+                $tpl->cache_id = $cachedTpl->cache_id;
+                $tpl->compile_id = $cachedTpl->compile_id;
+                $tpl->source = $cachedTpl->source;
+                if (isset($cachedTpl->compiled)) {
+                    $tpl->compiled = $cachedTpl->compiled;
+                } else {
+                    unset($tpl->compiled);
+                }
+                if ($caching != 9999 && isset($cachedTpl->cached)) {
+                    $tpl->cached = $cachedTpl->cached;
+                } else {
+                    unset($tpl->cached);
+                }
             } else {
-                $this->smarty->_cache['subTplInfo'][$name] = $count;
+                $tpl->templateId = $_templateId;
+                $tpl->template_resource = $template;
+                $tpl->cache_id = $cache_id;
+                $tpl->compile_id = $compile_id;
+                if (isset($uid)) {
+                    // for inline templates we can get all resource information from file dependency
+                    list($filepath, $timestamp, $type) = $tpl->compiled->file_dependency[ $uid ];
+                    $tpl->source = new \Smarty_Template_Source($smarty, $filepath, $type, $filepath);
+                    $tpl->source->filepath = $filepath;
+                    $tpl->source->timestamp = $timestamp;
+                    $tpl->source->exists = true;
+                    $tpl->source->uid = $uid;
+
+                    $pathinfo = pathinfo($tpl->source->filepath);
+                    $this->dispatch($pathinfo['filename'], $tpl->source->filepath);
+                } else {
+                    $tpl->source = \Smarty_Template_Source::load($tpl);
+
+                    $pathinfo = pathinfo($tpl->source->filepath);
+                    $this->dispatch($pathinfo['filename'], $tpl->source->filepath);
+                    unset($tpl->compiled);
+                }
+                if ($caching != 9999) {
+                    unset($tpl->cached);
+                }
             }
-            $this->dispatch($this->normalizeTemplateName($name));
+        } else {
+            // on recursive calls force caching
+            $forceTplCache = true;
+        }
+        $tpl->caching = $caching;
+        $tpl->cache_lifetime = $cache_lifetime;
+        // set template scope
+        $tpl->scope = $scope;
+        if (!isset($smarty->_cache[ 'tplObjects' ][ $tpl->templateId ]) && !$tpl->source->handler->recompiled) {
+            // check if template object should be cached
+            if ($forceTplCache || (isset($smarty->_cache[ 'subTplInfo' ][ $tpl->template_resource ]) &&
+                                   $smarty->_cache[ 'subTplInfo' ][ $tpl->template_resource ] > 1) ||
+                ($tpl->_isParentTemplate() && isset($smarty->_cache[ 'tplObjects' ][ $tpl->parent->templateId ]))
+            ) {
+                $smarty->_cache[ 'tplObjects' ][ $tpl->templateId ] = $tpl;
+            }
+        }
+
+        if (!empty($data)) {
+            // set up variable values
+            foreach ($data as $_key => $_val) {
+                $tpl->tpl_vars[ $_key ] = new \Smarty_Variable($_val, $this->isRenderingCache);
+            }
+        }
+        if ($tpl->caching == 9999) {
+            if (!isset($tpl->compiled)) {
+                $this->loadCompiled(true);
+            }
+            if ($tpl->compiled->has_nocache_code) {
+                $this->cached->hashes[ $tpl->compiled->nocache_hash ] = true;
+            }
+        }
+        $tpl->_cache = array();
+        if (isset($uid)) {
+            if ($smarty->debugging) {
+                if (!isset($smarty->_debug)) {
+                    $smarty->_debug = new \Smarty_Internal_Debug();
+                }
+                $smarty->_debug->start_template($tpl);
+                $smarty->_debug->start_render($tpl);
+            }
+            $tpl->compiled->getRenderedTemplateCode($tpl, $content_func);
+            if ($smarty->debugging) {
+                $smarty->_debug->end_template($tpl);
+                $smarty->_debug->end_render($tpl);
+            }
+        } else {
+            if (isset($tpl->compiled)) {
+                $tpl->compiled->render($tpl);
+            } else {
+                $tpl->render();
+            }
         }
     }
 
     /**
      * @param string $name
      */
-    protected function dispatch($name)
+    protected function dispatch($name, $path)
     {
         /** @var Factory $viewFactory */
         $viewFactory = $this->smarty->getViewFactory();
@@ -55,31 +153,14 @@ class SmartyTemplate extends \Smarty_Internal_Template
             $viewFactory,
             $viewFactory->getEngineResolver()->resolve('smarty'),
             $name,
-            null,
+            $path,
             []
         );
+
         $viewFactory->callCreator($view);
         $viewFactory->callComposer($view);
         foreach ($view->getData() as $key => $data) {
             $this->assign($key, $data);
         }
-    }
-
-    /**
-     * @param string $name
-     *
-     * @return string
-     */
-    protected function normalizeTemplateName($name)
-    {
-        $name = "\"$name\"";
-        if (preg_match('/^([\'"])(([A-Za-z0-9_\-]{2,})[:])?(([^$()]+)|(.+))\1$/', $name, $match)) {
-            $name = !empty($match[5]) ? $match[5] : $match[6];
-        }
-        $fileInfo = new \SplFileInfo($name);
-        $path = ($fileInfo->getPath() === '') ? null : $fileInfo->getPath() . '/';
-        $viewPathInfo = $path . $fileInfo->getBasename('.' . $fileInfo->getExtension());
-
-        return trim(str_replace('/', '.', $viewPathInfo), '\'"');
     }
 }


### PR DESCRIPTION
Debugbar output before...

![screen shot 2016-11-25 at 23 30 41](https://cloud.githubusercontent.com/assets/340752/20636602/74ebaace-b367-11e6-8115-fce7120120ed.png)

After...
![screen shot 2016-11-25 at 23 29 28](https://cloud.githubusercontent.com/assets/340752/20636603/7d6cadb0-b367-11e6-8130-ea903c034de9.png)


Don't merge this PR as I wanted your feedback before fully testing it and writing any test.

The main thing I don't like about this method is having to override the `_subTemplateRender()` method which is rather large. I couldn't see of any other way of getting the full file path to the sub template.

If you have any ideas, that'd be great