### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,17 +114,6 @@ edit config/ytake-laravel-smarty.php
 
 and more..!
 
-### use optimize command
-for production
-```bash
-$ php artisan optimize
-```
-
-for develop/debug
-```bash
-$ php artisan optimize --force
-```
-
 ## Basic
 easily use all the methods of Smarty  
 


### PR DESCRIPTION
`optimize` command has been [deprecated since Laravel 5.6](https://laravel-news.com/laravel-5-6-removes-artisan-optimize)