### PR TITLE
Fix required Illuminate versions

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,11 +18,11 @@
   "license": "MIT",
   "require": {
     "php": ">=7.0.0",
-    "illuminate/support": "^5.5",
-    "illuminate/view": "^5.5",
-    "illuminate/config": "^5.5",
-    "illuminate/console": "^5.5",
-    "illuminate/events": "^5.5",
+    "illuminate/support": "5.5.*|5.6.*",
+    "illuminate/view": "5.5.*|5.6.*",
+    "illuminate/config": "5.5.*|5.6.*",
+    "illuminate/console": "5.5.*|5.6.*",
+    "illuminate/events": "5.5.*|5.6.*",
     "smarty/smarty": "^3.1.31"
   },
   "require-dev": {


### PR DESCRIPTION
Laravel doesn't follow SemVer, so Laravel 5.7 could have breaking changes that break this package, which `^5.5` in the `composer.json` would allow!

See here for more info https://medium.com/@vinkla/laravel-packages-and-semantic-versioning-f62dc5accee5

 